### PR TITLE
Update README: citation and license correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,4 +305,4 @@ If you use EDsim in your research, please cite:
 
 ## License
 
-This project is released under the [MIT License](LICENSE).
+This project is released under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## Summary

- Replaces the placeholder `@article{edsim2025, ...}` citation with the full BibTeX entry for the preprint
  - Adds all 18 authors, DOI (`10.21203/rs.3.rs-8960989/v1`), year (2026), and notes it is under review at *npj Digital Medicine* on Research Square
- Fixes incorrect license reference: MIT → Apache 2.0 (matching the actual `LICENSE` file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)