### PR TITLE
Add Docker Compose containerization (closes #6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# OpenAI credentials — copy this file to .env and fill in your values.
+# .env is gitignored and will never be committed.
+
+# --- Standard OpenAI ---
+OPENAI_CLIENT=openai
+OPENAI_MODEL=gpt-3.5-turbo
+OPENAI_KEY=sk-...
+EMBEDDINGS_CLIENT=openai
+EMBEDDINGS_MODEL=text-embedding-ada-002
+EMBEDDINGS_KEY=sk-...
+
+# --- Azure OpenAI (uncomment and fill if using Azure) ---
+# OPENAI_CLIENT=azure
+# OPENAI_MODEL=gpt-35-turbo-0125
+# OPENAI_KEY=your-azure-key
+# OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
+# OPENAI_API_VERSION=2024-02-01
+# EMBEDDINGS_CLIENT=azure
+# EMBEDDINGS_MODEL=text-embedding-ada-002
+# EMBEDDINGS_KEY=your-azure-key
+# EMBEDDINGS_ENDPOINT=https://your-resource.openai.azure.com/
+# EMBEDDINGS_API_VERSION=2024-02-01
+
+# --- Cost tracking (optional, defaults shown) ---
+# EXPERIMENT_NAME=edsim
+# COST_UPPERBOUND=100.0
+# OPENAI_MODEL_COST_INPUT=0.0
+# OPENAI_MODEL_COST_OUTPUT=0.0
+# EMBEDDINGS_COST_INPUT=0.0
+# EMBEDDINGS_COST_OUTPUT=0.0

--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,9 @@ cython_debug/
 
 openai_config.json
 
+# Docker build artifacts
+docker/*.log
+
 storage/
 temp_storage/
 environment/frontend_server/compressed_storage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,25 @@ Create `openai_config.json` at the repo root (gitignored). Supports OpenAI or Az
 }
 ```
 
+## Docker Quickstart (recommended)
+
+```bash
+cp .env.example .env        # fill in your API credentials
+docker compose up --build   # starts frontend (:8000) + headless backend
+```
+
+Open http://localhost:8000 to confirm the frontend is running.
+
+To run the backend interactively instead:
+```bash
+docker compose run --rm backend python reverie.py --origin ed_sim_n5 --target my-run --browser no
+```
+
+To run tests inside the container:
+```bash
+docker compose run --rm backend python -m pytest /app/tests/backend/ /app/tests/analysis/ -v -p no:django
+```
+
 ## Running the Simulation
 
 ### Interactive mode (frontend + backend)

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,24 @@
+FROM python:3.9.12-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source
+COPY reverie/ ./reverie/
+COPY environment/frontend_server/static_dirs/ ./environment/frontend_server/static_dirs/
+COPY analysis/ ./analysis/
+COPY tests/ ./tests/
+COPY pytest.ini .
+# Note: seed simulation data (ed_sim_n5) must be provided at runtime via a
+# mounted volume or by copying into the container; it is not baked into the image.
+
+# Copy entrypoint
+COPY docker/backend-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /app/reverie/backend_server
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["python", "run_simulation.py"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,11 @@
+FROM python:3.9.12-slim
+
+WORKDIR /app
+
+COPY environment/frontend_server/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY environment/frontend_server/ .
+
+EXPOSE 8000
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.9"
+
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "8000:8000"
+    volumes:
+      - sim_storage:/app/storage
+      - sim_temp:/app/temp_storage
+    env_file: .env
+    restart: unless-stopped
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    volumes:
+      - sim_storage:/app/environment/frontend_server/storage
+      - sim_temp:/app/environment/frontend_server/temp_storage
+    env_file: .env
+    depends_on:
+      - frontend
+    restart: unless-stopped
+
+volumes:
+  sim_storage:
+  sim_temp:

--- a/docker/backend-entrypoint.sh
+++ b/docker/backend-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+STORAGE=/app/environment/frontend_server/storage
+SEED=$STORAGE/ed_sim_n5
+CURR=$STORAGE/curr_sim
+
+if [ ! -d "$CURR" ]; then
+    if [ -d "$SEED" ]; then
+        echo "[entrypoint] Seeding curr_sim from ed_sim_n5..."
+        cp -r "$SEED" "$CURR"
+    else
+        echo "[entrypoint] WARNING: ed_sim_n5 seed data not found. Mount storage volume or provide seed data before running the simulation."
+    fi
+fi
+
+exec "$@"

--- a/reverie/backend_server/persona/prompt_template/gpt_structure.py
+++ b/reverie/backend_server/persona/prompt_template/gpt_structure.py
@@ -1,3 +1,4 @@
+import os
 import time
 import json
 from pathlib import Path
@@ -24,11 +25,45 @@ def _is_retryable(exc):
     msg = str(exc).lower()
     return any(k in msg for k in ("server_error", "rate limit", "overloaded", "502", "503"))
 
+
+def _config_from_env() -> dict:
+    """Build openai_config from environment variables."""
+    return {
+        "client":               os.environ["OPENAI_CLIENT"],
+        "model":                os.environ["OPENAI_MODEL"],
+        "model-key":            os.environ["OPENAI_KEY"],
+        "model-endpoint":       os.environ.get("OPENAI_ENDPOINT", ""),
+        "model-api-version":    os.environ.get("OPENAI_API_VERSION", ""),
+        "model-costs": {
+            "input":  float(os.environ.get("OPENAI_MODEL_COST_INPUT", "0.0")),
+            "output": float(os.environ.get("OPENAI_MODEL_COST_OUTPUT", "0.0")),
+        },
+        "embeddings-client":     os.environ["EMBEDDINGS_CLIENT"],
+        "embeddings":            os.environ["EMBEDDINGS_MODEL"],
+        "embeddings-key":        os.environ["EMBEDDINGS_KEY"],
+        "embeddings-endpoint":   os.environ.get("EMBEDDINGS_ENDPOINT", ""),
+        "embeddings-api-version": os.environ.get("EMBEDDINGS_API_VERSION", ""),
+        "embeddings-costs": {
+            "input":  float(os.environ.get("EMBEDDINGS_COST_INPUT", "0.0")),
+            "output": float(os.environ.get("EMBEDDINGS_COST_OUTPUT", "0.0")),
+        },
+        "experiment-name": os.environ.get("EXPERIMENT_NAME", "edsim"),
+        "cost-upperbound": float(os.environ.get("COST_UPPERBOUND", "100.0")),
+    }
+
+
 CONFIG_PATH = Path(__file__).resolve().parents[4] / 'openai_config.json'
 
-config_path = CONFIG_PATH
-with open(config_path, "r") as f:
-    openai_config = json.load(f) 
+if os.environ.get("OPENAI_KEY"):
+    openai_config = _config_from_env()
+elif CONFIG_PATH.exists():
+    with open(CONFIG_PATH, "r") as f:
+        openai_config = json.load(f)
+else:
+    raise RuntimeError(
+        "No OpenAI credentials found. "
+        "Set OPENAI_KEY (and related env vars) or create openai_config.json."
+    )
 
 def setup_client(type: str, config: dict):
   """Setup the OpenAI client.


### PR DESCRIPTION
## Summary

- Adds `Dockerfile.backend` and `Dockerfile.frontend` both using `python:3.9.12-slim` to match the conda environment exactly
- Adds `docker-compose.yml` with two services (`frontend` port 8000, `backend` headless) sharing named volumes `sim_storage` and `sim_temp` for filesystem-based IPC
- Adds `docker/backend-entrypoint.sh` to seed `curr_sim` from `ed_sim_n5` on first container start
- Adds `.env.example` documenting all required credential env vars for OpenAI and Azure OpenAI
- Updates `gpt_structure.py` to load credentials from env vars first, falling back to `openai_config.json` (backwards compatible)
- Updates `CLAUDE.md` with a Docker quickstart section

## Test plan

- [x] `docker build -f Dockerfile.backend -t edsim-backend .` succeeds
- [x] All 42 unit tests pass inside the container: `docker run --rm edsim-backend python -m pytest /app/tests/backend/ /app/tests/analysis/ -v -p no:django`
- [ ] `cp .env.example .env` (fill credentials) then `docker compose up --build` starts both services
- [ ] `curl http://localhost:8000/` returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)